### PR TITLE
db に 52bit 以上の値で検索をかけない

### DIFF
--- a/dbi.py
+++ b/dbi.py
@@ -8,6 +8,8 @@ class dbi():
 
     def find_uri(self, uri_id):
         db_uri = self.__db.uri
+        if uri_id > 0xfffffffffffff:
+            return None
         ret = list(db_uri.find({'id': uri_id}))
         if len(ret) == 1:
             return {'uri': ret[0]['uri'], 'type': ret[0]['type']}

--- a/tests/test_dbi.py
+++ b/tests/test_dbi.py
@@ -51,3 +51,7 @@ class test_dbi(unittest.TestCase):
         self.assertEqual(self.db.find_uri(ret), {'uri': 'http://example.com/', 'type': 1})
         self.assertEqual(self.db.find_id_and_type('http://example.com/', 1), ret)
         self.assertEqual(self.db.update('http://example.com/', 1), ret)
+
+    def test_find_uri_id_over_52bit(self):
+        self.assertIsNone(self.db.find_uri(0xfffffffffffff))
+        self.assertIsNone(self.db.find_uri(0x10000000000000))


### PR DESCRIPTION
mongodb の精度の問題とエラー防止のためこのようにする。
